### PR TITLE
inject JSON $schema definition to the final document

### DIFF
--- a/src/main/java/com/siemens/sbom/standardbom/StandardBomParser.java
+++ b/src/main/java/com/siemens/sbom/standardbom/StandardBomParser.java
@@ -191,21 +191,22 @@ public class StandardBomParser
 
 
     @Nonnull
-    private String injectSchemaSpec(@Nonnull String json)
+    private String injectSchemaSpec(@Nonnull final String pJson)
     {
         String schemaAttribute = "  \"$schema\": \"http://cyclonedx.org/schema/bom-1.6.schema.json\","
             .concat(System.lineSeparator());
 
         // Check if $schema attribute already exists
-        if (json.contains("\"$schema\"")) {
-            return json;
+        if (pJson.contains("\"$schema\"")) {
+            return pJson;
         }
 
         // Find the position right after the opening curly brace
-        int insertPosition = json.indexOf("{\n") + 2;
+        final String insertMarker = '{' + System.lineSeparator();
+        int insertPosition = pJson.indexOf(insertMarker) + insertMarker.length();
 
         // Insert the $schema attribute at the found position
-        StringBuilder sb = new StringBuilder(json);
+        StringBuilder sb = new StringBuilder(pJson);
         sb.insert(insertPosition, schemaAttribute);
         return sb.toString();
     }

--- a/src/main/java/com/siemens/sbom/standardbom/StandardBomParser.java
+++ b/src/main/java/com/siemens/sbom/standardbom/StandardBomParser.java
@@ -184,7 +184,30 @@ public class StandardBomParser
         json = unescapeComponentFields(json);
         json = unescapeExtRefPurls(json);
         json = removeEmptyServicesMetadata(json);
+        json = injectSchemaSpec(json);
         return json.concat(System.lineSeparator());
+    }
+
+
+
+    @Nonnull
+    private String injectSchemaSpec(@Nonnull String json)
+    {
+        String schemaAttribute = "  \"$schema\": \"http://cyclonedx.org/schema/bom-1.6.schema.json\","
+            .concat(System.lineSeparator());
+
+        // Check if $schema attribute already exists
+        if (json.contains("\"$schema\"")) {
+            return json;
+        }
+
+        // Find the position right after the opening curly brace
+        int insertPosition = json.indexOf("{\n") + 2;
+
+        // Insert the $schema attribute at the found position
+        StringBuilder sb = new StringBuilder(json);
+        sb.insert(insertPosition, schemaAttribute);
+        return sb.toString();
     }
 
 

--- a/src/test/resources/com/siemens/sbom/standardbom/full-valid-1.4.cdx.json
+++ b/src/test/resources/com/siemens/sbom/standardbom/full-valid-1.4.cdx.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat" : "CycloneDX",
   "specVersion" : "1.4",
   "version" : 1,

--- a/src/test/resources/com/siemens/sbom/standardbom/full-valid.cdx.json
+++ b/src/test/resources/com/siemens/sbom/standardbom/full-valid.cdx.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat" : "CycloneDX",
   "specVersion" : "1.6",
   "version" : 1,


### PR DESCRIPTION
Final document should contain JSON $schema definitions 
Sample data should also contain the $schema definitions like:

```json
{
  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
  "bomFormat" : "CycloneDX",
  "specVersion" : "1.6",
...
```

and

```json
{
  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
  "bomFormat" : "CycloneDX",
  "specVersion" : "1.4",
...
```